### PR TITLE
[webhook] [auth] Use new authentication for retrieving the webhook.

### DIFF
--- a/freemius-webhook-listener.php
+++ b/freemius-webhook-listener.php
@@ -65,12 +65,6 @@ final class Freemius_WebHook_Listener {
         // Retrieve the request's body
         $input = @file_get_contents("php://input");
 
-        /**
-         * Freemius PHP SDK can be downloaded from GitHub:
-         * https://github.com/Freemius/php-sdk
-         */
-        require_once dirname(__FILE__) . '/includes/freemius/includes/sdk/Freemius.php';
-
         extract( self::$plugin );
 
         // Verify the authenticity of the request.


### PR DESCRIPTION
Hello,

We have added an easier authentication method for verifying incoming webhook request from Freemius. You can read about it here: https://freemius.com/blog/changelog/new-feature-added-authentication-support-for-custom-webhook-events/

This PR brings the following changes:

1. Use the new `HTTP_X_SIGNATURE` based authentication.
2. Avoid sending additional API requests to Freemius and instead directly leverage the authenticated event payload.

Thanks.